### PR TITLE
add `files` key to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "box model",
     "DOM"
   ],
+  "files": [
+    "/dist"
+  ],
   "main": "dist/css-box-model.cjs.js",
   "module": "dist/css-box-model.esm.js",
   "sideEffects": false,


### PR DESCRIPTION
This pull request adds the `files` key to `package.json` so that only the `dist` directory and `README.md` is included in the installed package.

The reason this is necessary is because I am using babel with rollup to bundle this package. babel is trying to use the `.babelrc` of this package to transpile the bundle but it doesn't need to because it is already transpiled.

I can work around this by marking this package _external_ in rollup but I would rather not have to do that for my use case and it would be better to use the `files` key to implicitly exclude `.babelrc` instead.