### PR TITLE
update references to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/atlassian/react-beautiful-dnd.git"
+    "url": "https://github.com/alexreardon/css-box-model.git"
   },
   "bugs": {
-    "url": "https://github.com/atlassian/react-beautiful-dnd/issues"
+    "url": "https://github.com/alexreardon/css-box-model/issues"
   },
   "keywords": [
     "css",


### PR DESCRIPTION
Indeed, this package is used in `react-beautiful-dnd`, but the source code of the package is here.

After updating the information, there will be correct links on the package page on NPM: https://www.npmjs.com/package/css-box-model